### PR TITLE
Change default amount of seconds per refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ MAX_FAILURE=3
 TTY=true
 
 # This define the number of SECONDS to wait between each verification.
-WAIT_FOR=10
+WAIT_FOR=15
 
 # This define the limit when the bot will repay your debt.
 LTV_LIMIT=43


### PR DESCRIPTION
Oracle updates happen every 15 seconds, as _jess_ (TFL dev.) has confirmed on Discord.
To query Luna's price faster than that is pointless and wasteful.