### PR TITLE
Add logging to compound, Add compoundMins to configs

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -34,16 +34,16 @@ export default {
 		borrow: 30,
 	},
 
-        compoundMins: {
-				// This defines the minimum required for compound to swap ANC for Luna 
-				anc: 5,
+	compoundMins: {
+		// This defines the minimum required for compound to swap ANC for Luna 
+		anc: 5,
 
-				// This defines the minimum required for compound to swap Luna for bluna
-				luna: 5,
+		// This defines the minimum required for compound to swap Luna for bluna
+		luna: 5,
 
-				// This defines the minimum required for compound to add the bluna into borrow
-				bluna: 5,
-        },
+		// This defines the minimum required for compound to add the bluna into borrow
+		bluna: 5,
+	},
 
 	notification: {
 		tty: true,

--- a/config.ts
+++ b/config.ts
@@ -35,9 +35,14 @@ export default {
 	},
 
         compoundMins: {
-                anc: 5,
-                luna: 5,
-                bluna: 5,
+				// This defines the minimum required for compound to swap ANC for Luna 
+				anc: 5,
+
+				// This defines the minimum required for compound to swap Luna for bluna
+				luna: 5,
+
+				// This defines the minimum required for compound to add the bluna into borrow
+				bluna: 5,
         },
 
 	notification: {

--- a/config.ts
+++ b/config.ts
@@ -34,6 +34,12 @@ export default {
 		borrow: 30,
 	},
 
+        compoundMins: {
+                anc: 5,
+                luna: 5,
+                bluna: 5,
+        },
+
 	notification: {
 		tty: true,
 		telegram: true,

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,4 @@
 require('dotenv').config()
-import dedent from 'dedent-js'
 import { Telegraf } from 'telegraf'
 import config from './config'
 import { Bot } from './src/Bot'
@@ -12,25 +11,8 @@ if (config.telegram.apiKey) {
 
 	tgBot.command('ping', (ctx) => ctx.reply('Pong!'))
 
-	tgBot.command('info', (ctx) => {
-		const { config, wallet, status } = bot.getContext()
-
-		ctx.replyWithHTML(dedent`<b>v0.2.6 - Anchor Borrow / Repay Bot</b>
-			Made by Romain Lanz
-			
-			<b>Network:</b> <code>${config.chainId === 'columbus-4' ? 'Mainnet' : 'Testnet'}</code>
-			<b>Address:</b>
-			<a href="https://finder.terra.money/${config.chainId}/address/${wallet}">
-				${wallet}
-			</a>
-			
-			<b>Status:</b> <code>${status}</code>
-
-			<u>Configuration:</u>
-				- <b>SAFE:</b> <code>${config.ltv.safe}%</code>
-				- <b>LIMIT:</b> <code>${config.ltv.limit}%</code>
-				- <b>BORROW:</b> <code>${config.ltv.borrow}%</code>
-		`)
+	tgBot.command('info', () => {
+		bot.info()
 	})
 
 	// tgBot.command('repay', async (ctx) => {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -347,7 +347,7 @@ export class Bot {
 
 				Logger.toBroadcast(`Swapped ANC for Luna`, 'tgBot')
 			} else {
-				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.anc}</code> minimum.... Skipping ANC conversion`, 'tgBot')
+				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.anc}</code> minimum... Skipping ANC swap`, 'tgBot')
 			}
 
 			const lunaBalance = await this.getLunaBalance()
@@ -367,7 +367,7 @@ export class Bot {
 				await this.#client.tx.broadcast(tx)
 				Logger.toBroadcast(`Swapped Luna for bLuna`, 'tgBot')
 			} else {
-				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.luna}</code> minimum.... Skipping Luna conversion`, 'tgBot')
+				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.luna}</code> minimum... Skipping Luna swap`, 'tgBot')
 			}
 
 			const { balance } = await this.#client.wasm.contractQuery<any>(this.#addressProvider.bLunaToken(), {
@@ -387,11 +387,11 @@ export class Bot {
 					.execute(this.#wallet, { gasPrices: '0.15uusd' })
 
 				Logger.toBroadcast(
-					`Compounded... <code>${bLunaBalance.toFixed(3)} bLuna</code>`,
+					`Compounded <code>${bLunaBalance.toFixed(3)} bLuna</code>`,
 					'tgBot'
 				)
 			}else {
-				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.bluna}</code> minimum.... Skipping bLuna compound`, 'tgBot')
+				Logger.toBroadcast(`less than <code>${this.#config.compoundMins.bluna}</code> minimum... Skipping bLuna compound`, 'tgBot')
 			}
 			
 		} catch (e) {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -99,7 +99,7 @@ export class Bot {
 			value = +value
 		}
 
-		if (path === 'ltv.safe') {
+		else if (path === 'ltv.safe') {
 			if (+value >= this.#config.ltv.limit) {
 				Logger.log(`You cannot go over <code>${this.#config.ltv.limit}</code>.`)
 				return
@@ -108,7 +108,7 @@ export class Bot {
 			value = +value
 		}
 
-		if (path === 'ltv.borrow') {
+		else if (path === 'ltv.borrow') {
 			if (+value >= this.#config.ltv.safe) {
 				Logger.log(`You cannot go over <code>${this.#config.ltv.safe}</code>.`)
 				return
@@ -117,13 +117,30 @@ export class Bot {
 			value = +value
 		}
 
-		if (path === 'options.shouldBorrowMore') {
+		else if (path === 'options.shouldBorrowMore') {
 			if (!isBoolean(value)) {
 				Logger.log(`The value must be a boolean (true/false).`)
 				return
 			}
 
 			value = toBoolean(value)
+		}
+
+		else if (path === 'compoundMins.anc') {
+			value = +value
+		}
+
+		else if (path === 'compoundMins.luna') {
+			value = +value
+		}
+
+		else if (path === 'compoundMins.bluna') {
+			value = +value
+		}
+
+		else {
+			Logger.log(`Invalid set option, <code>${path}</code> is not a recognized option`)
+			return
 		}
 
 		dset(this.#config, path, value)

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -413,7 +413,7 @@ export class Bot {
 					.execute(this.#wallet, { gasPrices: '0.15uusd' })
 
 				Logger.toBroadcast(
-					`Compounded <code>${bLunaBalance.toFixed(3)} bLuna</code>`,
+					`Compounded <code>${bLunaBalance.toFixed(0)} bLuna</code>`,
 					'tgBot'
 				)
 			}else {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -64,6 +64,10 @@ export class Bot {
 			market: Denom.USD,
 		}
 
+		this.info();
+	}
+
+	info() {
 		Logger.log(dedent`<b>v0.2.6 - Anchor Borrow / Repay Bot</b>
 				Made by Romain Lanz
 				
@@ -77,6 +81,11 @@ export class Bot {
 					- <b>SAFE:</b> <code>${this.#config.ltv.safe}%</code>
 					- <b>LIMIT:</b> <code>${this.#config.ltv.limit}%</code>
 					- <b>BORROW:</b> <code>${this.#config.ltv.borrow}%</code>
+				
+				<u>Compound minimums:</u>
+					- <b>ANC:</b> <code>${this.#config.compoundMins.anc}</code>
+					- <b>LUNA:</b> <code>${this.#config.compoundMins.luna}</code>
+					- <b>BLUNA:</b> <code>${this.#config.compoundMins.bluna}</code>
 		`)
 	}
 


### PR DESCRIPTION
Signed-off-by: Luigi311 <luigi311.lg@gmail.com>

Adds more information to the compound output to get a better understanding of what happened. Sample output from testnet with luna sitting in the wallet to meet minimums.

```
ANC balance: 60
Swapped ANC for Luna
Luna Balance: 10
Swapped Luna for bLuna
bLuna Balance: 11
Compounded 11.020 bLuna
```

This is with not enough to meet the minimums for the compound
```
ANC balance: 340
Swapped ANC for Luna
Luna Balance: 0
less than 5 minimum... Skipping Luna swap
bLuna Balance: 1
less than 5 minimum... Skipping bLuna compound
```

Minimums are all stored in the config.ts file under compoundMins.

Closes #25 

Move info command from main into bot and use info command during init so you dont have to maintain the print twice.

Return error if you use set with an invalid option