### PR TITLE
Fix compute ltv, amount to repay, amount to borrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 package-lock.json
-.env
+**/.env*

--- a/config.ts
+++ b/config.ts
@@ -22,13 +22,13 @@ export default {
 
 	ltv: {
 		// This define the limit when the bot will repay your debt.
-		limit: process.env.LTV_LIMIT || 43,
+		limit: process.env.LTV_LIMIT || 56,
 
 		// This define the safe-limit that the bot will reach when repaying or borrowing more.
-		safe: process.env.LTV_SAFE || 35,
+		safe: process.env.LTV_SAFE || 45,
 
 		// This define the low-limit when the bot will borrow more.
-		borrow: process.env.LTV_BORROW || 30,
+		borrow: process.env.LTV_BORROW || 40,
 	},
 
 	compoundMins: {
@@ -45,5 +45,9 @@ export default {
 	notification: {
 		tty: true,
 		telegram: true,
+	},
+
+	anchor: {
+		maxLTV: 60,
 	},
 }

--- a/main.ts
+++ b/main.ts
@@ -155,7 +155,7 @@ if (process.env.CHAIN_ID && process.env.CHAIN_ID.split('-').length !== 2) {
 	throw new Error('Invalid CHAIN ID provided.')
 }
 
-if (config.ltv.limit > 49) {
+if (config.ltv.limit > config.anchor.maxLTV) {
 	throw new Error('ltv.limit is too high.')
 }
 

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -107,8 +107,8 @@ export class Bot {
 
 	set(path: string, value: any) {
 		if (path === 'ltv.limit') {
-			if (+value > 49) {
-				Logger.log('You cannot go over <code>49</code>.')
+			if (+value > this.#config.anchor.maxLTV-1) {
+				Logger.log(`You cannot go over <code>${this.#config.anchor.maxLTV-1}</code>.`)
 				return
 			}
 
@@ -496,23 +496,24 @@ export class Bot {
 	async computeLTV() {
 		const borrowedValue = await this.getBorrowedValue()
 		const borrowLimit = await this.getBorrowLimit()
-
-		return borrowedValue.dividedBy(borrowLimit.times(2)).times(100)
+		return borrowedValue.dividedBy(borrowLimit).times(this.#config.anchor.maxLTV)
 	}
 
 	async computeAmountToRepay(target = this.#config.ltv.safe) {
 		const borrowedValue = await this.getBorrowedValue()
 		const borrowLimit = await this.getBorrowLimit()
-		const amountForSafeZone = new Decimal(target).times(borrowLimit.times(2).dividedBy(100))
-
+		const maxLTV = new Decimal(this.#config.anchor.maxLTV)
+		const amountForSafeZone = new Decimal(target).times(borrowLimit.dividedBy(maxLTV))
+		
 		return borrowedValue.minus(amountForSafeZone)
 	}
 
 	async computeAmountToBorrow(target = this.#config.ltv.safe) {
 		const borrowedValue = await this.getBorrowedValue()
 		const borrowLimit = await this.getBorrowLimit()
+		const maxLTV = new Decimal(this.#config.anchor.maxLTV)
 
-		return new Decimal(target).times(borrowLimit.times(2)).dividedBy(100).minus(borrowedValue)
+		return new Decimal(target).times(borrowLimit.dividedBy(maxLTV)).minus(borrowedValue)
 	}
 
 	getDeposit(): Promise<Decimal> {


### PR DESCRIPTION
This will fix the incorrect calculations for LTV, amount to repay and borrow. The LTV values have changed and I have put in a request with to add getMaxLTV and getSafeLTV functions to the anchor API at https://github.com/Anchor-Protocol/anchor.js/issues/27 this will allow us to remove the config.anchor.ltv and instead have that value grabbed dynamically so we don't have to manually update it when it changes or for other collaterals.
Signed-off-by: Luigi311 <luigi311.lg@gmail.com>